### PR TITLE
Fix document click listener for webview

### DIFF
--- a/src/hooks/document_click_listener.rs
+++ b/src/hooks/document_click_listener.rs
@@ -1,13 +1,18 @@
-use dioxus::prelude::use_drop;
+use dioxus::prelude::*;
+use dioxus::document;
 use crate::models::clicked::ClickListeners;
 use once_cell::unsync::OnceCell;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast;
+#[cfg(target_arch = "wasm32")]
 use web_sys::wasm_bindgen::closure::Closure;
+#[cfg(target_arch = "wasm32")]
 use web_sys::{window, EventTarget, MouseEvent};
 thread_local! {
  static LISTENER_INITIALIZED: OnceCell<ClickListeners> = OnceCell::new();
 }
 
+#[cfg(target_arch = "wasm32")]
 fn initialize_document_click_listener(clicked: ClickListeners) {
     let closure = Closure::wrap(Box::new(move |evt: MouseEvent| {
         let target = evt.target().and_then(|t| t.dyn_into::<EventTarget>().ok());
@@ -22,9 +27,31 @@ fn initialize_document_click_listener(clicked: ClickListeners) {
         .document()
         .unwrap()
         .add_event_listener_with_callback("click", closure.as_ref().unchecked_ref())
-       .unwrap();
+        .unwrap();
 
     closure.forget();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn initialize_document_click_listener(clicked: ClickListeners) {
+    let rt = Runtime::current().unwrap();
+    let cur_scope = current_scope_id().unwrap();
+    rt.spawn(cur_scope, async move {
+        let mut eval = document::eval(
+            r#"
+                document.addEventListener('click', (evt) => {
+                    const target = evt.target;
+                    const id = target ? target.id : null;
+                    dioxus.send(id);
+                });
+            "#,
+        );
+        while let Ok(id) = eval.recv::<Option<String>>().await {
+            for callback in clicked.id().borrow_mut().iter_mut() {
+                callback(id.clone());
+            }
+        }
+    });
 }
 
 pub(crate) fn use_document_click_listener() -> ClickListeners {


### PR DESCRIPTION
## Summary
- rewrite document click listener
- use `document::eval` for non-wasm targets to forward clicks from JS

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685aa26d0c948328b663ff365871ed1d